### PR TITLE
Fix error in the parameters of the DCMIP2.1 test case

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimFlowsTestCases"
 uuid = "55a4ed1b-ebae-44a5-bd1f-98d158431b8a"
 authors = ["The ClimFlows contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [compat]
 julia = "1.6"

--- a/src/julia/DCMIP2012.jl
+++ b/src/julia/DCMIP2012.jl
@@ -38,7 +38,7 @@ struct DCMIP{N,P} <: TestCaseHPE
         # non-generic parameters
         X = 500
         Rd, radius, g = 287.0, 6.37122e6/X, 9.81 # from DCMIP 2012 document v1.6_23 p.4
-        T0, d, xi, h0 = 300.0, 5000.0, 400.0, 250.0 # from DCMIP 2012 document v1.6_23 p.30
+        T0, d, xi, h0 = 300.0, 5000.0, 4000.0, 250.0 # from DCMIP 2012 document v1.6_23 p.30
         mountain = (lambda_m=pi/4, phi_m=0.0, delta_m=d/radius, xi_m=xi/radius, Phi_m=h0*g)
         p = override(F, (p0=1e5, pv0=Rd*T0, u0=20.0, mountain...), user)
         new{21, typeof(p)}(p)


### PR DESCRIPTION
The period for the oscillating part of the mountain was 400m instead of 4000m, leading to (i) underresolved orography and (ii) steeper-than-desired slopes.
